### PR TITLE
Get rid of alarm()

### DIFF
--- a/lib/Net/NTP.pm
+++ b/lib/Net/NTP.pm
@@ -171,14 +171,17 @@ sub get_ntp_response {
 
     ## receive with deadline
     my $data;
-    eval {
-        local $SIG{ALRM} = sub { die "Net::NTP timed out getting NTP packet\n"; };
-        alarm($TIMEOUT);
+    my $rin = '';
+    vec($rin, $sock->fileno(), 1) = 1;
+    my $rout = $rin;
+    select($rout, undef, undef, $TIMEOUT);
+    if (vec($rout, $sock->fileno(), 1)) {
         $sock->recv($data, 960)
-          or die "recv() failed: $!\n";
-        alarm(0);
-    };
-    alarm 0;
+            or die "recv() failed: $!\n";
+    }
+    else {
+        die "Net::NTP timed out getting NTP packet\n";
+    }
 
     my $rectime = time; # T4
     my $pkt = Net::NTP::Packet->decode($data, $xmttime, $rectime);


### PR DESCRIPTION
This patch gets rid of `alarm()`, for better cross platform compatibility.
Originally posted [here](https://rt.cpan.org/Public/Bug/Display.html?id=59607).
Tested on both Linux and Windows.